### PR TITLE
Fix requests without API key and query parameters

### DIFF
--- a/lib/OpenDota.js
+++ b/lib/OpenDota.js
@@ -28,14 +28,14 @@ class OpenDota {
             if (!this.tokenBucket.take())
                 reject("API rate limit exceeded.");
             
-            let fullPath = this.BASEPATH;
+            let fullPath = `${this.BASEPATH}${path}`;
 
             if (queryParameters && this.apiKey) {
-                fullPath = `${fullPath}${path}?${querystring.stringify({ api_key: this.apiKey, ...queryParameters })}`;
+                fullPath = `${fullPath}?${querystring.stringify({ api_key: this.apiKey, ...queryParameters })}`;
             } else if (this.apiKey) {
-                fullPath = `${fullPath}${path}?${querystring.stringify({ api_key: this.apiKey })}`;
+                fullPath = `${fullPath}?${querystring.stringify({ api_key: this.apiKey })}`;
             } else if (queryParameters) {
-                fullPath = `${fullPath}${path}?${querystring.stringify(queryParameters)}`;
+                fullPath = `${fullPath}?${querystring.stringify(queryParameters)}`;
             }
 
             https.request({


### PR DESCRIPTION
Hello.
After experimenting with this package without an API key, I noticed that some methods kept returning the API schema instead of the data itself. After going through the code, I found that the request path was not being used if there was no API key and no query parameters.

Example to reproduce:
```typescript
import { OpenDota } from 'opendota.js';

async function main() {
  const api = new OpenDota();
  const response = await api.getPlayer('1202292236');
  console.log(response);
}

main();
```