### PR TITLE
Point to the correct type declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opendota.js",
   "version": "2.0.2",
   "description": "A NodeJS OpenDota API wrapper.",
-  "main": "index.js",
+  "main": "index.d.js",
   "types": "./types/index.ts",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Super minor quality of life improvement for typescript enjoyers. VSCode wasn't finding the type declarations in `types/index.d.ts` because of the missing `.d.` in the type dec filename.

Tested by linking locally w/ my fix, and intellisense was much happier.